### PR TITLE
Bumped protobuf python dependency and protoc version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
-         version: '3.21.9'
+         version: '4.21.9'
 
     - name: Generate proto files
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,7 +48,7 @@ jobs:
         protoc -I ${{ env.PROTO_FOLDER }} --python_out=./wirepas_mesh_messaging/proto ${{ env.PROTO_FOLDER }}/*.proto
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,10 +23,10 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
-         version: '3.14.0'
+         version: '3.21.9'
 
     - name: Generate proto files
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-20-04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ['3.5', '3.6', '3.7', '3.8']

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,6 +38,8 @@ jobs:
       
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+         version: '3.19.0'
       
     - name: Print the installed protoc version
       run: protoc --version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,8 +38,9 @@ jobs:
       
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
-      with:
-         version: '4.21.9'
+      
+    - name: Print the installed protoc version
+      run: protoc --version
 
     - name: Generate proto files
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,10 +23,10 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20-04
     strategy:
       matrix:
-        python-version: ['3.5.10']
+        python-version: ['3.5', '3.6', '3.7', '3.8']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: ['3.5.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # 3.12.2 version is used as it is
 # the version available in alpine 3.12 (for protobuf cpp version)
-protobuf>=3.12.2,<4.0
+protobuf==4.21.9


### PR DESCRIPTION
Updated protobuf dependency to 4.21.9
Updated protoc version used to 3.21.9

**Note**: it is possible that this will break the docker image generated on top of an alpine distribution. It is pushed nonetheless to be able to fulfill a customer request and deliver the wheel (with all the appropriate warning about the fact that this is somewhat a pre-release)