### PR TITLE
Update protobuf python dependency to 4.X

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
-         version: '3.14.0'
+         version: '3.19.0'
 
     - name: Generate proto files
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-# 3.12.2 version is used as it is
-# the version available in alpine 3.12 (for protobuf cpp version)
-protobuf>=3.12.2,<4.0
+# Protobuf version above major version 4 require the file to be compiled with 
+# protoc 3.19 or newer.
+# TODO Alpine image currently support protoc 3.18+, so it is required to wait for an
+# alpine image with updated protoc before a new image can be generated
+protobuf>=4.0


### PR DESCRIPTION
Updated protobuf dependency to be greater than 4.0. Updated protoc version in github action to 3.19

Note: it is likely that this will break the docker image generated from an alpine distribution. Indeed, at this moment in time, the maximum version of protoc on alpine distribution is 3.18. It is pushed nonetheless to be able to fulfill a customer request and deliver the wheel (with all the appropriate warning about the fact that this is somewhat a pre-release)