### PR TITLE
Increment protobuf requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# Minimum of 3.19 as protoc useed needed it
-protobuf>=3.19.2
+# Minimum of 3.20.0 because we use google.protobuf.internal.builder
+protobuf>=3.20.0


### PR DESCRIPTION
When trying to use the latest wirepass-mesh-messaging-python version with wirepass-mqtt-library, I got this error:

```
  from app import wirepas_client
File "/code/app/wirepas_client.py", line 3, in <module>
  from wirepas_mqtt_library import WirepasNetworkInterface
File "/usr/local/lib/python3.11/site-packages/wirepas_mqtt_library/__init__.py", line 1, in <module>
  from .wirepas_network_interface import WirepasNetworkInterface
File "/usr/local/lib/python3.11/site-packages/wirepas_mqtt_library/wirepas_network_interface.py", line 11, in <module>
  import wirepas_mesh_messaging as wmm
File "/usr/local/lib/python3.11/site-packages/wirepas_mesh_messaging/__init__.py", line 22, in <module>
  from .get_configs import GetConfigsRequest, GetConfigsResponse
File "/usr/local/lib/python3.11/site-packages/wirepas_mesh_messaging/get_configs.py", line 10, in <module>
  from .proto import GenericMessage
File "/usr/local/lib/python3.11/site-packages/wirepas_mesh_messaging/proto/__init__.py", line 5, in <module>
  from .error_pb2 import *
File "/usr/local/lib/python3.11/site-packages/wirepas_mesh_messaging/proto/error_pb2.py", line 5, in <module>
  from google.protobuf.internal import builder as _builder
```

I solved it by incrementing the protobuf version requirement, it looks like `error_pb2.py` (auto-generated?) depends on builder, which seems to be added in protobuf 3.20.0, see: https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.0, especially the line: `*[Breaking change] Protobuf python generated codes are simplified. Descriptors and message
classes' definitions are now dynamic created in internal/builder.py.`