### PR TITLE
Fix protobuf dependency version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
-         version: '29.x'
+         version: '29.3'
          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate proto files

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
     keywords=about["__keywords__"],
     packages=find_packages(exclude=["contrib", "docs", "tests", "examples"]),
     install_requires=[
-        "protobuf~=5.0"
+        "protobuf~=5.29.3"
     ]
 )


### PR DESCRIPTION
Protobuf runtime version should always be newer than the protoc version used. Setting a fixed protoc version in the github action, and setting the required protobuf version to be at least the same as the protoc version.

More info:
https://protobuf.dev/support/cross-version-runtime-guarantee/